### PR TITLE
[FIX] 1년마다 역할 자동 갱신

### DIFF
--- a/src/main/java/org/example/tackit/TackitApplication.java
+++ b/src/main/java/org/example/tackit/TackitApplication.java
@@ -2,10 +2,12 @@ package org.example.tackit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableScheduling
 public class TackitApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/tackit/domain/mypage/repository/MemberDetailRepository.java
+++ b/src/main/java/org/example/tackit/domain/mypage/repository/MemberDetailRepository.java
@@ -1,16 +1,30 @@
 package org.example.tackit.domain.mypage.repository;
 
 import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MemberDetailRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email); //email로 사용자 정보를 가져옴
 
+    // 1년마다 뉴비 -> 시니어 자동 갱신
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Member m " +
+            "SET m.role = :newRole " +
+            "WHERE m.role = :oldRole " +
+            "AND m.joinedYear <= :thresholdYear")
+    int bulkUpdateRole(@Param("oldRole") Role oldRole,
+                       @Param("newRole") Role newRole,
+                       @Param("thresholdYear") int thresholdYear);
     // 닉네임 중복확인
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/example/tackit/domain/mypage/service/MemberScheduler.java
+++ b/src/main/java/org/example/tackit/domain/mypage/service/MemberScheduler.java
@@ -1,0 +1,30 @@
+package org.example.tackit.domain.mypage.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.Role;
+import org.example.tackit.domain.mypage.repository.MemberDetailRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberScheduler {
+
+    private final MemberDetailRepository memberDetailRepository;
+
+    // 매년 1월 1일 0시 0분 0초에 실행
+    @Transactional
+    @Scheduled(cron = "0 0 0 1 1 *")
+    public void updateSeniorMembers() {
+        int currentYear = LocalDate.now().getYear();
+        int updatedCount = memberDetailRepository.bulkUpdateRole(Role.NEWBIE, Role.SENIOR, currentYear);
+        System.out.println("업데이트된 멤버 수 = " + updatedCount);
+    }
+
+}
+

--- a/src/test/java/org/example/tackit/MemberSchedulerTest.java
+++ b/src/test/java/org/example/tackit/MemberSchedulerTest.java
@@ -1,0 +1,56 @@
+package org.example.tackit;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.example.tackit.domain.entity.Member;
+import org.example.tackit.domain.entity.Role;
+import org.example.tackit.domain.entity.Status;
+import org.example.tackit.domain.mypage.repository.MemberDetailRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class MemberSchedulerTest {
+
+    @Autowired
+    private MemberDetailRepository memberDetailRepository;
+
+    @Autowired
+    private EntityManager em; // 영속성 컨텍스트 선언
+
+    @Test
+    void testBulkUpdateRole() {
+        // given: 2024년에 가입한 NEWBIE 멤버 저장 -> 테스트용 멤버
+        Member newbie = Member.builder()
+                .email("test@test.com")
+                .password("pw")
+                .nickname("뉴비")
+                .organization("ORG")
+                .role(Role.NEWBIE)
+                .joinedYear(2024)
+                .status(Status.ACTIVE)
+                .build();
+        memberDetailRepository.save(newbie);
+
+        int currentYear = 2025;
+        int thresholdYear = currentYear - 1;
+
+        // when: bulk update 실행
+        int updatedCount = memberDetailRepository.bulkUpdateRole(Role.NEWBIE, Role.SENIOR, thresholdYear);
+
+        // then: 업데이트된 row 수 확인
+        assertThat(updatedCount).isEqualTo(1);
+
+        // 캐시 초기화 후 DB에서 다시 조회 (영속성 컨텍스트)
+        em.clear();
+        Member updatedMember = memberDetailRepository.findById(newbie.getId()).orElseThrow();
+
+        // role이 SENIOR로 바뀌었는지 확인
+        assertThat(updatedMember.getRole()).isEqualTo(Role.SENIOR);
+    }
+}
+


### PR DESCRIPTION
### 이슈 번호
> #109 

### 작업 내용
* 매년 1월 1일 0시 0분마다 자동 전환 (NEWBIE -> SENIOR)
   * 테스트 코드 통과
