### PR TITLE
refactor: #157 - 게시글 본문 글자 수 제한 없도록 db 스키마 수정

### DIFF
--- a/src/main/java/org/example/tackit/domain/entity/FreePost.java
+++ b/src/main/java/org/example/tackit/domain/entity/FreePost.java
@@ -26,6 +26,8 @@ public class FreePost implements ReportablePost {
     private Member writer;
 
     private String title;
+
+    @Lob
     private String content;
     private LocalDateTime createdAt;
     private Post type;

--- a/src/main/java/org/example/tackit/domain/entity/QnAPost.java
+++ b/src/main/java/org/example/tackit/domain/entity/QnAPost.java
@@ -27,6 +27,8 @@ public class QnAPost implements ReportablePost {
     private Member writer;
 
     private String title;
+
+    @Lob
     private String content;
     private LocalDateTime createdAt;
     private Post type;

--- a/src/main/java/org/example/tackit/domain/entity/TipPost.java
+++ b/src/main/java/org/example/tackit/domain/entity/TipPost.java
@@ -26,6 +26,8 @@ public class TipPost implements ReportablePost {
     private Member writer;
 
     private String title;
+
+    @Lob
     private String content;
     private LocalDateTime createdAt;
 


### PR DESCRIPTION
### 이슈 번호
> #158 

### 작업 내용
* 게시글 본문 글자 수 제한 없도록 db 스키마 수정
* private String content에 `@Lob` 어노테이션 추가
